### PR TITLE
不处理mqtt服务器主动断开连接时发送的消息

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -699,6 +699,8 @@ class Client
                 $this->_recvPingResponse = true;
                 $this->debugDump('Recv PINGRESP package', '<-');
                 break;
+            case MQTTConst::CMD_DISCONNECT:
+                break;
             default:
                 $this->debugDump('Recv unknow package, cmd: ' . $cmd, '<-');
                 echo 'unknow cmd';


### PR DESCRIPTION
如果长期没有任何操作时服务器会主动断开连接并发送一条断开消息
这时客户端没有处理`MQTTConst::CMD_DISCONNECT`会报错`unknow cmd`
